### PR TITLE
Fixed module's name in 03-TierArchitecture. It was 03-RESTCentric, now i...

### DIFF
--- a/03-TierArchitecture/pom.xml
+++ b/03-TierArchitecture/pom.xml
@@ -17,6 +17,6 @@
   <modules>
     <module>01-Horizontal</module>
     <module>02-EJBCentric</module>
-    <module>03-RESTCentric</module>
+    <module>03-RestCentric</module>
   </modules>
 </project>


### PR DESCRIPTION
A very little fix at 03-TierArchitecture/pom.xml file.

P.S. thanks for sharing those examples
